### PR TITLE
Fix MoE one_hot lines

### DIFF
--- a/model.py
+++ b/model.py
@@ -331,7 +331,7 @@ class MoELayer(hk.Module):
         )
         def moe_slow_matmul1(input, weight, scales, index, prob):
             weight = weight * scales
-            one_hot_indices = jax.nn.one_hot(index.reshape(-1), 8, axis=0)
+            one_hot_indices = jax.nn.one_hot(index.reshape(-1), self.num_experts, axis=0)
             all_expert_output = jnp.einsum("mk,bkn->bmn", input, weight)
             output = jnp.einsum("bm,bmn->mn", one_hot_indices, all_expert_output)
             return output
@@ -351,7 +351,7 @@ class MoELayer(hk.Module):
         )
         def moe_slow_matmul2(input, weight, scales, index, prob):
             weight = weight * scales
-            one_hot_indices = jax.nn.one_hot(index.reshape(-1), 8, axis=0)
+            one_hot_indices = jax.nn.one_hot(index.reshape(-1), self.num_experts, axis=0)
             all_expert_output = jnp.einsum("mk,bkn->bmn", input, weight)
             output = jnp.einsum("bm,bmn->mn", one_hot_indices, all_expert_output)
             return jax.lax.psum(output, axis_name="model")


### PR DESCRIPTION
## Summary
- compact one-hot index lines for MoE matrix multiplications

## Testing
- `python -m py_compile checkpoint.py model.py run.py runners.py`


------
https://chatgpt.com/codex/tasks/task_e_68436b2f84d883228d0c4cf3cd63dd69